### PR TITLE
Switch from storing settings in config.json to storm.yaml

### DIFF
--- a/streamparse/cli/submit.py
+++ b/streamparse/cli/submit.py
@@ -145,6 +145,7 @@ def submit_topology(name=None, env_name=None, options=None, force=False,
                     wait=None, simple_jar=True, override_name=None):
     """Submit a topology to a remote Storm cluster."""
     config = get_config()
+    streamparse_config = config['streamparse']
     name, topology_file = get_topology_definition(name)
     env_name, env_config = get_env_config(env_name)
     topology_class = get_topology_from_file(topology_file)

--- a/streamparse/util.py
+++ b/streamparse/util.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import importlib
-import os
 import re
 import shutil
 import subprocess
@@ -178,7 +177,7 @@ def get_topology_definition(topology_name=None):
     else:
         topology_file = "{}.py".format(os.path.join(topology_path,
                                                     topology_name))
-        if not os.path.exists(topology_file):
+        if not exists(topology_file):
             die("Topology definition file not found {}. You need to "
                 "create a topology definition file first."
                 .format(topology_file))
@@ -360,9 +359,9 @@ def get_ui_json(env_name, api_path):
 def prepare_topology():
     """Prepare a topology for JAR creation"""
     resources_dir = join("_resources", "resources")
-    if os.path.isdir(resources_dir):
+    if isdir(resources_dir):
         shutil.rmtree(resources_dir)
-    if os.path.exists('src'):
+    if exists('src'):
         shutil.copytree("src", resources_dir)
     else:
         raise FileNotFoundError('Your project must have a "src" directory.')
@@ -425,10 +424,10 @@ def get_topology_from_file(topology_file):
     """
     Given a filename for a topology, import the topology and return the class
     """
-    topology_dir, mod_name = os.path.split(topology_file)
+    topology_dir, mod_name = split(topology_file)
     # Remove .py extension before trying to import
     mod_name = mod_name[:-3]
-    sys.path.append(os.path.join(topology_dir, '..', 'src'))
+    sys.path.append(join(topology_dir, '..', 'src'))
     sys.path.append(topology_dir)
     mod = importlib.import_module(mod_name)
     for attr in mod.__dict__.values():


### PR DESCRIPTION
This isn't quite ready for primetime yet, but I wanted to create the PR as a discussion point.

What currently works is that if we find you have a config.json file, we'll automatically load it and then dump the settings in there into a `streamparse` dict within `storm.yaml`. `get_config` and everything downstream of it has been adapted to handle this extra level of nesting in the dict that `get_config` returns.

What I have not done yet, but would like to do, is switching our environment-specific settings to match the general `storm.yaml` setting names (i.e., `nimbus.host` or `nimbus.seeds` instead of just `nimbus`, and `topology.workers` instead of `workers`), and then falling back on the `storm.yaml` settings if you haven't setup an environment at all. This would allow people to reuse what they may already have instead of potentially putting the settings in two places in two different formats.

Since we'll start parsing `storm.yaml` with this PR, I'm sure there are some other settings that we could probably pull out of it that we don't currently use that might be useful.
