### PR TITLE
Make tests run on current versions of Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 'pypy3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 'pypy3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Update the Python versions to remove EOL versions, and also update to GitHub Actions versions that are still supported.