### PR TITLE
Add release instructions

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ Integrates with Apache Storm.
    topologies
    api
    develop
+   releases
    faq
 
 .. image:: images/quickstart.gif

--- a/doc/source/releases.rst
+++ b/doc/source/releases.rst
@@ -1,0 +1,10 @@
+# Cutting a new release
+
+1. Update the version number in `version.py` using semver versioning rules.
+2. Tag your commit with the new version number. ie `git tag -a v0.1.0.dev0 -m "v0.1.0.dev0"` or `git tag -a v0.1.0 -m "v0.1.0" <commit hash>`
+3. Push the tag to GitHub. `git push origin v0.1.0`
+4. Install twine and build the package. `pip install twine` and `pip install build`
+5. Build the package. `python -m build`
+6. Upload the package to test.pypi.org. `twine upload --repository testpypi dist/*` and verify you can install the test package.
+7. Upload the package to pypi.org. `twine upload dist/*` and verify you can install the package.
+4. Create a new release on GitHub. `


### PR DESCRIPTION
The [streamparse docs](https://streamparse.readthedocs.io/en/master/#) do not contains explicit release instructions. This adds instructions for future developers.