### PR TITLE
Bump to 5.0.1

### DIFF
--- a/streamparse/version.py
+++ b/streamparse/version.py
@@ -28,5 +28,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))


### PR DESCRIPTION
After looking at #501, I was going to replace `pkg_resources` since it's going to stop working in 3.12, but it turns out I don't have time to do that right now. Instead, we can cut this as 5.0.1 to fix the one bug and move on. That replacement will have to happen someday, though.